### PR TITLE
Fix registerless bit conditions in circuit_to_instruction (#7395)

### DIFF
--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -113,14 +113,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
         if condition:
             reg, val = condition
             if isinstance(reg, Clbit):
-                idx = 0
-                for creg in circuit.cregs:
-                    if reg not in creg:
-                        idx += creg.size
-                    else:
-                        cond_reg = creg
-                        break
-                rule[0].condition = (c[idx + list(cond_reg).index(reg)], val)
+                rule[0].condition = (clbit_map[reg], val)
             elif reg.size == c.size:
                 rule[0].condition = (c, val)
             else:

--- a/releasenotes/notes/fix-circuit_to_instruction_single-bit-condition-db75291ce921001a.yaml
+++ b/releasenotes/notes/fix-circuit_to_instruction_single-bit-condition-db75291ce921001a.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixed conversion of :class:`.QuantumCircuit`\ s with classical conditions on
+    single, registerless :class:`.Clbit` \s to :class:`~.circuit.Instruction`\ s when
+    using the :func:`.circuit_to_instruction` function or the
+    :meth:`.QuantumCircuit.to_instruction` method.  For example, the following
+    will now work::
+
+        from qiskit.circuit import QuantumCircuit, Qubit, Clbit
+
+        qc = QuantumCircuit([Qubit(), Clbit()])
+        qc.h(0).c_if(qc.clbits[0], 0)
+        qc.to_instruction()


### PR DESCRIPTION
* Fix registerless bit conditions in circuit_to_instruction

This version of the change is stable for backports, but a more thorough
refactor of `circuit_to_instruction` is in order to support multiple
registers, overlapping registers and remove the creation of unnecessary
registers.

* Fix ambiguous cross-reference

* Be consistent in writing conditions

Co-authored-by: Kevin Krsulich <kevin@krsulich.net>

Co-authored-by: Kevin Krsulich <kevin@krsulich.net>

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


